### PR TITLE
Fix vppinit to make sure that the tunnel interface is always first.

### DIFF
--- a/internal/vppinit/iface.go
+++ b/internal/vppinit/iface.go
@@ -132,6 +132,6 @@ func initInterface(srcIP net.IP, conf *configurator.Config) error {
 	for _, ip := range nets {
 		vppIface.IpAddresses = append(vppIface.IpAddresses, ip.String())
 	}
-	conf.GetVppConfig().Interfaces = append(conf.GetVppConfig().GetInterfaces(), vppIface)
+	conf.GetVppConfig().Interfaces = append([]*vpp_interfaces.Interface{vppIface}, conf.GetVppConfig().GetInterfaces()...)
 	return nil
 }


### PR DESCRIPTION
This is important, because things like l2xconnect expect the
last two interfaces to be what should be cross connected.