### PR TITLE
Fix issue after incorrect update from cmd-template

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters-settings:
   golint:
     min-confidence: 0.8
   goimports:
-    local-prefixes: github.com/networkservicemesh
+    local-prefixes: github.com/networkservicemesh/cmd-forwarder-vppagent
   gocyclo:
     min-complexity: 15
   maligned:


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

The mechanism of excluding paths from cmd-template had worked wrong. The problem is fixed on cmd-template side: https://github.com/networkservicemesh/cmd-template/commit/601284321e10527b94b3572e7bead15800470bfd

This PR just fixes golangci.yaml file after update cmd-template