### PR TITLE
fix: Restore .golangci.yml after incorrect merge by nsm-bot

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ run:
   tests: true
 linters-settings:
   goheader:
-    template-path: ".license/template.txt"
+    template-path: ".ci/license/template.txt"
     values:
       const:
         year: 2020
@@ -30,7 +30,7 @@ linters-settings:
   golint:
     min-confidence: 0.8
   goimports:
-    local-prefixes: github.com/networkservicemesh
+    local-prefixes: github.com/networkservicemesh/cmd-forwarder-vppagent
   gocyclo:
     min-complexity: 15
   maligned:
@@ -169,3 +169,12 @@ issues:
   exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    - path: main.go
+      linters:
+        - funlen
+      text: "Function 'main'"
+    - path: main_test.go
+      linters:
+        - funlen
+      text: "Function 'TestKernelToKernel' is too long"


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

Bug fix for the cmd-template to prevent these kind issues: https://github.com/networkservicemesh/cmd-template/pull/23